### PR TITLE
Fix helm charts access token for prod deploys

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: osuAkatsuki/common-helm-charts
-          token: ${{ secrets.COMMON_HELM_CHARTS_PAT }}
+          token: ${{ secrets.COMMON_HELM_CHARTS_PAT_2024 }}
           path: common-helm-charts
 
       - name: Clear pending deployments


### PR DESCRIPTION
Fixes deployment error: https://github.com/osuAkatsuki/payments-service/actions/runs/8458361357/job/23172419264

Switches from an outdated repository secret to the update organization secret.