### PR TITLE
Fix PayPal IPN request id fallback

### DIFF
--- a/app/api/webhooks/paypal.py
+++ b/app/api/webhooks/paypal.py
@@ -114,7 +114,7 @@ def schedule_success_webhook(fields: dict[str, Any]) -> None:
 @router.post("/webhooks/paypal_ipn")
 async def process_notification(
     request: Request,
-    x_request_id: str = Header(default_factory=uuid.uuid4),
+    x_request_id: str = Header(default_factory=lambda: str(uuid.uuid4())),
 ):
     request_data = await request.body()
     logging.info(  # TODO: change to debug once stabilized


### PR DESCRIPTION
## Summary
- Convert the generated PayPal IPN request id fallback to a string so FastAPI header validation accepts requests without `X-Request-Id`.

## Verification
- Replayed the PayPal IPN route locally with the problematic payload and stubbed external clients.
- Confirmed both missing and provided `X-Request-Id` cases return 200.
- Ran `git diff --check`.
- Ran `/tmp/payments-service-venv/bin/python -m compileall -q app`.