### PR TITLE
Log FastAPI request validation errors

### DIFF
--- a/app/exception_handling.py
+++ b/app/exception_handling.py
@@ -8,6 +8,11 @@ from types import TracebackType
 from typing import Any
 from typing import Optional
 
+import fastapi.exception_handlers
+from fastapi import Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
 ExceptionHook = Callable[
     [type[BaseException], BaseException, Optional[TracebackType]],
     Any,
@@ -41,6 +46,19 @@ def internal_thread_exception_handler(
         exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
         extra={"thread_vars": vars(args.thread)},
     )
+
+
+async def request_validation_exception_handler(
+    request: Request,
+    exc: RequestValidationError,
+) -> JSONResponse:
+    logging.warning(
+        "Request validation failed",
+        extra={"body": exc.body, "path": request.url.path},
+        exc_info=exc,
+    )
+    original_handler = fastapi.exception_handlers.request_validation_exception_handler
+    return await original_handler(request, exc)
 
 
 def hook_exception_handlers() -> None:

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
 
 import app.clients
 import app.exception_handling
@@ -23,6 +24,11 @@ async def lifespan(asgi_app: FastAPI) -> AsyncIterator[None]:
 
 
 asgi_app = FastAPI(lifespan=lifespan)
+asgi_app.add_exception_handler(
+    RequestValidationError,
+    # TODO[better-typing]: https://github.com/encode/starlette/pull/2403
+    app.exception_handling.request_validation_exception_handler,  # type: ignore[arg-type]
+)
 
 
 @asgi_app.get("/_health")


### PR DESCRIPTION
## Summary
- Add a FastAPI `RequestValidationError` handler that logs request validation failures before returning the standard 422 response.
- Include the request path, validation body, and exception info in the log entry.

## Verification
- Ran a local FastAPI route replay that intentionally triggers validation failure and confirmed it returns 422 while logging `Request validation failed` with path/body/exception info.
- Ran `git diff --check`.
- Ran `/tmp/payments-service-venv/bin/python -m compileall -q app main.py`.