### PR TITLE
Fail production deploy on SSH command errors

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -51,6 +51,7 @@ jobs:
           username: root
           key: ${{ secrets.SERVER_SSH_KEY }}
           script: |
+            set -e
             cd /opt/akatsuki
             docker compose pull payments-service
             docker compose up -d payments-service


### PR DESCRIPTION
## Summary
- Add `set -e` to the production SSH deploy script so a failed `docker compose pull` fails the GitHub Actions job instead of being masked by a later command.
- Leave the GHCR auth flow equivalent to score-service: build uses the Actions token, remote deploy relies on the server Docker credentials.

## Verification
- Ran `git diff --check`.
- Confirmed the production server can now pull `ghcr.io/osuakatsuki/payments-service:latest` after refreshing root Docker GHCR credentials.