### PR TITLE
Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Check out latest commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -29,12 +29,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/osuakatsuki/payments-service
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Updates GitHub Actions dependencies to current Node 24-compatible major versions to avoid the Node 20 deprecation warning now emitted by GitHub-hosted runners.

Mechanical workflow-only changes:
- actions/checkout -> v7
- docker/login-action -> v4
- docker/metadata-action -> v6
- docker/build-push-action -> v7
- docker/setup-qemu-action -> v4
- docker/setup-buildx-action -> v4
- actions/setup-python -> v6
- actions/upload-artifact -> v7
- actions/download-artifact -> v8
- hashicorp/setup-terraform -> v4
- actions/github-script -> v9
- azure/setup-helm -> v5

Validation: `git diff --check`.
